### PR TITLE
Mark get_true() as convergent.

### DIFF
--- a/libtrue/true.h
+++ b/libtrue/true.h
@@ -29,6 +29,6 @@
 #ifndef __LIBTRUE_TRUE_H__
 #define	__LIBTRUE_TRUE_H__
 
-bool get_true(void);
+bool get_true(void) __attribute__((convergent));
 
 #endif /* __LIBTRUE_TRUE_H__ */


### PR DESCRIPTION
When libtrue is run via CUDA, marking it as convergent can allow more
efficient work group allocation.