### PR TITLE
Add Python bindings for fast libtrue access.

### DIFF
--- a/py-libtrue/libtrue_build.py
+++ b/py-libtrue/libtrue_build.py
@@ -1,0 +1,15 @@
+from cffi import FFI
+ffi = FFI()
+
+_LIBTRUE_CDEF = '''
+bool get_true(void);
+'''
+_SRC_PATH = '../libtrue/true.c'
+ffi.set_source('true._true',
+               open(_SRC_PATH).read(),
+               extra_compile_args=['-Wall', '-Wextra', '-Werror',
+                                   '-I../libtrue/'])
+ffi.cdef(_LIBTRUE_CDEF)
+
+if __name__ == '__main__':
+    ffi.compile(verbose=True)

--- a/py-libtrue/setup.py
+++ b/py-libtrue/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup
+
+setup(
+    name = "py-libtrue",
+    version = "0.0.1",
+    author = "Matt Joras",
+    author_email = "matt.joras@gmail.com",
+    description = "Python bindings for libtrue.",
+    license = "BSD",
+    url = "https://github.com/zxombie/libtrue",
+    packages=['true'],
+    classifiers=[
+        "License :: OSI Approved :: BSD License",
+    ],
+    setup_requires=["cffi>=1.0.0"],
+    cffi_modules=["libtrue_build.py:ffi"],
+    install_requires=["cffi>=1.0.0"],
+)

--- a/py-libtrue/true/__init__.py
+++ b/py-libtrue/true/__init__.py
@@ -1,0 +1,1 @@
+from true import *

--- a/py-libtrue/true/true.py
+++ b/py-libtrue/true/true.py
@@ -1,0 +1,7 @@
+from _true import lib
+
+"""
+Function for returning True, implemented in C for performance reasons.
+"""
+def get_true():
+    return bool(lib.get_true())


### PR DESCRIPTION
Python programs have a desperate need for guaranteed truth. By binding
libtrue with cffi we allow Python programs fast access to the libtrue C
library. This is altogether a better option that re-implementing libtrue
in pure Python.

To install and use, you need the cffi port installed, then simply do the following:

```
% cd py-libtrue
% python setup.py build
% sudo python setup.py install
...
>>> import true
>>> true.get_true()
True
```