### PR TITLE
Add Go bindings for fast libtrue access

### DIFF
--- a/go-libtrue/libtrue/libtrue.go
+++ b/go-libtrue/libtrue/libtrue.go
@@ -1,0 +1,13 @@
+package libtrue
+
+// #cgo CFLAGS: -g -Wall -I/usr/include
+// #cgo LDFLAGS: -L/usr/lib -ltrue
+// #include <stdbool.h>
+// #include <true.h>
+// bool get_true(void);
+import "C"
+
+// GetTrue function returns true implemented in C for performance reasons.
+func GetTrue() C.bool {
+	return C.bool(C.get_true())
+}

--- a/go-libtrue/main.go
+++ b/go-libtrue/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+	"libtrue"
+)
+
+func main() {
+	ret := libtrue.GetTrue()
+	fmt.Printf("%T\n", ret)
+	fmt.Println(ret)
+}

--- a/libtrue/Makefile
+++ b/libtrue/Makefile
@@ -5,6 +5,8 @@ SHLIB_MAJOR=	0
 
 SRCS=		true.c
 
+INCS=		true.h
+
 MAN=
 
 .include <bsd.lib.mk>

--- a/true/Makefile
+++ b/true/Makefile
@@ -2,6 +2,8 @@
 
 PROG=	true
 
+BINDIR=	/usr/bin
+
 CFLAGS=	-I${.CURDIR:H}/libtrue
 LDADD=	-L../libtrue -ltrue
 


### PR DESCRIPTION
Bind libtrue using cgo in order to help gophers to find the truth fastly
using performant C libtrue. It's a far better and viable option than
re-implementing libtrue in pure Go.